### PR TITLE
Require platform governance team review for all docs changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Require governance review for all platform-docs changes
+* @zavestudios/platform-governance-reviewers


### PR DESCRIPTION
## Summary
- add CODEOWNERS for full-repository governance review coverage
- require `@zavestudios/platform-governance-reviewers` as code owner

## Why
- enforce architectural/governance review at PR boundary
- keep platform-docs authority changes explicitly reviewed

## Testing
- documentation-only change reviewed locally