### PR TITLE
Add no-cost Terraform policy automation scripts

### DIFF
--- a/_platform/TERRAFORM_POLICY_AUTOMATION.md
+++ b/_platform/TERRAFORM_POLICY_AUTOMATION.md
@@ -1,0 +1,56 @@
+# Terraform Policy Automation (No-Cost Path)
+
+This runbook applies class-based branch protection to Terraform repositories when
+organization-level rulesets are not available.
+
+## Class Model
+
+Terraform repositories use topic-based class tags:
+
+- `modules`
+- `sandbox`
+- `production`
+
+All Terraform repos must also include the `terraform` topic.
+
+## Enforcement Applied
+
+For the repository default branch:
+
+- Enforce admins
+- Require pull request review
+- Dismiss stale approvals on push
+- Require conversation resolution
+- Require linear history
+- Disallow force pushes
+- Disallow deletions
+
+Class-specific review policy:
+
+- `sandbox`: 1 approval, code owner review not required
+- `modules`: 1 approval, code owner review required
+- `production`: 2 approvals, code owner review required
+
+## Scripts
+
+- `scripts/apply-terraform-repo-protection.sh`
+  - Apply policy to one repository.
+- `scripts/apply-terraform-repo-protection-bulk.sh`
+  - Apply policy to all repos in an org with `terraform` topic.
+
+## Usage
+
+Run manually by human:
+
+```bash
+# Single repo
+./scripts/apply-terraform-repo-protection.sh zavestudios iac-tf-sbx-example
+
+# Bulk apply for org
+./scripts/apply-terraform-repo-protection-bulk.sh zavestudios
+```
+
+## Prerequisites
+
+- `gh` authenticated as a user with admin permission on target repositories
+- `jq` installed

--- a/scripts/apply-terraform-repo-protection-bulk.sh
+++ b/scripts/apply-terraform-repo-protection-bulk.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Apply class-based Terraform branch protections to all repos in an org
+# that carry the "terraform" topic.
+#
+# Usage:
+#   ./scripts/apply-terraform-repo-protection-bulk.sh zavestudios
+
+ORG="${1:?org required}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+repos="$(gh api "orgs/$ORG/repos" --paginate --jq '.[] | select(.archived == false) | .name')"
+
+count=0
+while IFS= read -r repo; do
+  [[ -z "$repo" ]] && continue
+  topics="$(gh api "repos/$ORG/$repo/topics" --jq '.names')"
+  if echo "$topics" | jq -e 'index("terraform") != null' >/dev/null; then
+    "$SCRIPT_DIR/apply-terraform-repo-protection.sh" "$ORG" "$repo"
+    count=$((count + 1))
+  fi
+done <<< "$repos"
+
+echo "Applied protections to $count terraform repos in $ORG."

--- a/scripts/apply-terraform-repo-protection.sh
+++ b/scripts/apply-terraform-repo-protection.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Apply class-based branch protection to a single Terraform repo.
+# Class is determined from topics: modules | sandbox | production.
+#
+# Usage:
+#   ./scripts/apply-terraform-repo-protection.sh zavestudios iac-tf-sbx-example
+
+ORG="${1:?org required}"
+REPO="${2:?repo required}"
+FULL_REPO="${ORG}/${REPO}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required." >&2
+  exit 1
+fi
+
+DEFAULT_BRANCH="$(gh repo view "$FULL_REPO" --json defaultBranchRef --jq '.defaultBranchRef.name')"
+TOPICS_JSON="$(gh api "repos/$FULL_REPO/topics" --jq '.names')"
+
+has_topic() {
+  local topic="$1"
+  echo "$TOPICS_JSON" | jq -e --arg t "$topic" 'index($t) != null' >/dev/null
+}
+
+required_reviews=1
+require_code_owner_review=false
+
+if has_topic "production"; then
+  required_reviews=2
+  require_code_owner_review=true
+elif has_topic "modules"; then
+  required_reviews=1
+  require_code_owner_review=true
+elif has_topic "sandbox"; then
+  required_reviews=1
+  require_code_owner_review=false
+else
+  echo "ERROR: missing class topic. Expected one of: modules, sandbox, production." >&2
+  echo "Topics: $TOPICS_JSON" >&2
+  exit 1
+fi
+
+payload="$(jq -n \
+  --argjson reviews "$required_reviews" \
+  --argjson codeowners "$require_code_owner_review" \
+'{
+  required_status_checks: null,
+  enforce_admins: true,
+  required_pull_request_reviews: {
+    dismiss_stale_reviews: true,
+    require_code_owner_reviews: $codeowners,
+    require_last_push_approval: false,
+    required_approving_review_count: $reviews
+  },
+  restrictions: null,
+  required_linear_history: true,
+  allow_force_pushes: false,
+  allow_deletions: false,
+  block_creations: false,
+  required_conversation_resolution: true,
+  lock_branch: false,
+  allow_fork_syncing: false
+}')"
+
+echo "Applying protection to $FULL_REPO@$DEFAULT_BRANCH"
+echo "Topics: $TOPICS_JSON"
+echo "required_reviews=$required_reviews require_code_owner_review=$require_code_owner_review"
+
+gh api -X PUT "repos/$FULL_REPO/branches/$DEFAULT_BRANCH/protection" --input - <<<"$payload" >/dev/null
+
+echo "Done."


### PR DESCRIPTION
## Summary
- add class-based Terraform branch protection script for single-repo application
- add bulk script to apply protections to all org repos tagged with `terraform`
- add runbook documenting class model (`modules|sandbox|production`) and enforcement settings

## Why
- provide control-plane-aligned safety controls without org-level rulesets
- preserve no-cost path on current GitHub plan

## Testing
- executed single-repo script against `zavestudios/kubernetes-platform-infrastructure`
- executed bulk script against `zavestudios` (applied to 1 terraform repo)
