### PR TITLE
Add GitOps model documentation

### DIFF
--- a/_platform/GITOPS_MODEL.md
+++ b/_platform/GITOPS_MODEL.md
@@ -61,7 +61,7 @@ FluxCD manages:           ArgoCD manages:
 ├── Namespaces            ├── Deployments
 ├── NetworkPolicies       ├── Services
 ├── ResourceQuotas        ├── Ingresses
-├── PodSecurityPolicies   ├── ConfigMaps (tenant)
+├── Kyverno policies      ├── ConfigMaps (tenant)
 ├── Big Bang              ├── Secrets (tenant, sealed)
 └── ArgoCD itself         └── HorizontalPodAutoscalers
 ```


### PR DESCRIPTION
## Summary
- add `_platform/GITOPS_MODEL.md`
- document GitOps-plane implementation split between FluxCD and ArgoCD
- define authority boundaries, ArgoCD application pattern, and formation-phase manual steps

## Notes
- this is documentation only; no runtime behavior changes
