### PR TITLE
doc: admission policy model, Flux reconciliation layering, and Kyverno CI enforcement gate

### DIFF
--- a/_platform/ADMISSION_POLICY_MODEL.md
+++ b/_platform/ADMISSION_POLICY_MODEL.md
@@ -1,0 +1,120 @@
+# ZaveStudios — Admission Policy Model v0.1
+
+This document defines how Kyverno admission policies are authored, organized, and tested on the ZaveStudios platform.
+
+## Chapter Guide
+
+**Purpose**
+
+Establish the two-layer pattern for admission control so that platform defaults are set at admission without requiring charts or workload authors to know about them.
+
+**Read this when**
+
+- authoring a new Kyverno policy
+- a workload is blocked by an admission policy at deploy time
+- deciding whether a requirement belongs in a policy or in a chart value
+- writing Kyverno tests for the CI pipeline
+
+**Read next**
+
+- `ENFORCEMENT_MATRIX.md` for where policies sit in the enforcement stack
+- `GITOPS_MODEL.md` for how policies are reconciled to the cluster
+
+---
+
+## Two-Layer Pattern
+
+Kyverno policies operate in two distinct modes. Using the correct mode for each requirement prevents unnecessary coupling between platform policy and workload chart schemas.
+
+### Mutate — Platform Defaults at Admission
+
+A mutating policy intercepts a resource at admission and adds or modifies fields before the resource is persisted. The workload chart does not need to know the fields exist.
+
+Use mutate when a requirement is a **platform default**: a value that should always be present but that workloads should not need to declare. Labels, annotations, and security context baselines are the canonical examples.
+
+### Validate — Invariants at Admission
+
+A validating policy rejects resources that do not meet a condition. The workload must satisfy the condition or be blocked.
+
+Use validate when a requirement is a **hard invariant**: a condition that must never be absent and that workloads are expected to declare. Restricting image registries, requiring non-root UIDs, or preventing privilege escalation are canonical examples.
+
+**Decision rule:**
+
+If a field should be present on every pod regardless of what the chart author wrote, use mutate. If a field must be set to a specific value by the workload author and the absence or wrong value is a security failure, use validate.
+
+The chart schema rejection problem — where a chart's `values.schema.json` rejects injected values like `podLabels` as additional properties — does not occur with mutating policies because the mutation happens at the Kubernetes API server level, not at Helm template rendering.
+
+---
+
+## Add-if-Absent Idiom
+
+Mutating policies that inject platform defaults must not overwrite values that the chart or workload already set. Use the `+()` syntax in `patchStrategicMerge` to add a field only if it is absent:
+
+```yaml
+mutate:
+  patchStrategicMerge:
+    metadata:
+      labels:
+        +(app.kubernetes.io/name): "{{ request.object.metadata.labels.release || 'unknown' }}"
+        +(app.kubernetes.io/version): "{{ request.object.metadata.labels.version || 'unset' }}"
+```
+
+The `+()` prefix means: apply this patch only if the key does not already exist. If the chart sets `app.kubernetes.io/name`, the policy leaves it alone.
+
+---
+
+## Autogen Behavior
+
+Kyverno automatically extends Pod-level rules to Deployment, StatefulSet, DaemonSet, Job, and CronJob pod templates via generated `autogen-*` rules.
+
+Write policies targeting `Pod`. Kyverno generates the controller variants. Do not manually duplicate rules for each controller kind.
+
+The autogen rules appear in `kubectl describe clusterpolicy` output and are the rules that fire on Deployment admission. If a Deployment is blocked by an autogen rule, the fix is the same as for the Pod-level rule — the autogen rule is a mechanical projection of it.
+
+---
+
+## Repo Location and Naming
+
+All platform Kyverno policies live in `platform/policies/kyverno/` in the gitops repository. One file per policy.
+
+Naming convention:
+
+- `inject-*` — mutating policies that add platform defaults
+- `require-*` — validating policies that enforce required fields
+- `restrict-*` — validating policies that block disallowed values
+
+The `kustomization.yaml` in that directory is the Flux reconciliation entry point. Add new policy files there.
+
+---
+
+## CI Fidelity
+
+`kyverno apply` in the CI pipeline processes mutating policies before validating policies, in the same order that the Kubernetes admission webhook chain runs them. This means:
+
+1. A mutating policy injects a label
+2. The validating policy that requires that label sees the mutated resource, not the original
+
+CI results are therefore faithful to cluster admission behavior. A workload that passes `kyverno apply` in CI will pass admission on the cluster, and vice versa, provided the policy set in CI matches the policy set on the cluster.
+
+This is why shifting Kyverno checks left into the CI pipeline (platform-pipelines#60) covers both policy types and eliminates the deploy-time discovery loop.
+
+---
+
+## Authoring Checklist
+
+When writing a new policy:
+
+1. Decide mutate or validate using the decision rule above.
+2. Use `+(key)` for any mutating patch that should not overwrite existing values.
+3. Target `Pod` and let autogen handle controllers.
+4. Name the file `inject-*`, `require-*`, or `restrict-*` per the naming convention.
+5. Add the file to `platform/policies/kyverno/kustomization.yaml`.
+6. Write a `kyverno test` case that covers at least one passing and one failing resource.
+
+---
+
+## Related Documentation
+
+- `ENFORCEMENT_MATRIX.md` — maps platform rules to enforcement points including Kyverno policies
+- `GITOPS_MODEL.md` — describes how platform policies are reconciled to the cluster
+- `DIAGNOSTIC_MODEL.md` — gap-analysis lens for rendered vs live state

--- a/_platform/ENFORCEMENT_MATRIX.md
+++ b/_platform/ENFORCEMENT_MATRIX.md
@@ -52,6 +52,7 @@ Canonical authorities:
 | Contract changes require compatibility and migration path | `platform-docs` pull request | Documentation gate for compatibility window and migration notes | Contract-breaking change without versioned migration and compatibility updates | `platform-docs` | Hard fail |
 | GitOps remains lifecycle authority for deployment state | Runtime reconciliation boundary | Reconciliation policy and drift detection controls | Out-of-band runtime mutation or unmanaged drift | `gitops` | Alert + gated remediation |
 | kubectl instructions remain human-gated in docs | Documentation pull request | Markdown lint/policy check for manual-step labeling | kubectl instruction missing required `Requires cluster access:` label | `platform-docs` | Hard fail |
+| Kubernetes manifests and Helm-rendered resources must satisfy enforced Kyverno policies before reaching the cluster | `gitops` pull request | `kyverno apply` against versioned policy snapshot in `platform/policies/kyverno/enforce/`; HelmRelease changes rendered via `helm template` before validation | Any violation of an Enforce-mode ClusterPolicy (BigBang-inherited or platform-authored) | `platform-pipelines` + `gitops` | Hard fail |
 
 ---
 
@@ -60,6 +61,7 @@ Canonical authorities:
 - **Tenant/portfolio pull request**: validation before merge in workload repositories.
 - **Any repository pull request**: validation applied to all repositories regardless of category.
 - **Infrastructure/control pull requests**: validation for repositories that can affect shared substrate or governance.
+- **`gitops` pull request**: validation applied to HelmRelease and tenant manifest changes before merge into the GitOps repository.
 - **Runtime reconciliation boundary**: post-merge enforcement at desired-state reconciliation layer.
 - **Documentation pull request**: validation of platform documents and operational guidance.
 

--- a/_platform/GITOPS_MODEL.md
+++ b/_platform/GITOPS_MODEL.md
@@ -219,6 +219,52 @@ Once generators stabilize:
 
 ---
 
+## Reconciliation Layering
+
+FluxCD reconciliation has three distinct ordering mechanisms. Using the wrong one is a common source of stalls.
+
+### Kustomization `dependsOn`
+
+Controls inter-Kustomization ordering. Flux will not begin reconciling Kustomization B until Kustomization A has **applied** its resources (not necessarily until they are healthy).
+
+Use this for tier ordering — runtime before services, services before tenants.
+
+```yaml
+spec:
+  dependsOn:
+    - name: on-prem-platform-runtime
+```
+
+### HelmRelease `dependsOn`
+
+Controls intra-tier ordering. Use when one HelmRelease within a tier must be healthy before another starts — for example, an operator before its CRD-dependent workload.
+
+```yaml
+spec:
+  dependsOn:
+    - name: cert-manager
+      namespace: platform
+```
+
+### `wait: true` on a Kustomization
+
+Changes what "reconciled" means for a Kustomization from "resources applied" to "resources healthy." Flux will not mark the Kustomization ready until all applied resources report a healthy status.
+
+**This is a stall point.** If any resource in the Kustomization is unhealthy — including a HelmRelease that is cycling through upgrade retries — Flux marks the Kustomization as not ready and stops processing it. Subsequent git commits that fix the underlying issue will not be picked up until the Kustomization unstalls.
+
+**Decision rule:**
+
+- If nothing `dependsOn` this Kustomization, do not set `wait: true`. There is no downstream consumer waiting on the health signal, and the only effect is blocking self-reconciliation.
+- If a downstream Kustomization does `dependsOn` this one, evaluate whether health-gating is actually required. `dependsOn` without `wait: true` gives apply-ordering; `wait: true` adds health-gating. Most tier dependencies need ordering, not health-gating.
+
+**Operational rule:**
+
+When a Kustomization stalls and pushing new commits has no effect, check whether `wait: true` is set and a resource in that Kustomization is unhealthy. The fix is either to resolve the unhealthy resource or remove `wait: true` if the health gate is not load-bearing.
+
+Do not iterate on symptoms by pushing more commits before understanding why Flux is not picking them up.
+
+---
+
 ## FluxCD Bootstrap
 
 FluxCD is installed via `gitops/bootstrap/` and pointed at `clusters/on-prem/`.


### PR DESCRIPTION
## Summary

- Adds `ADMISSION_POLICY_MODEL.md` documenting Kyverno mutate/validate authoring patterns
- Adds Flux reconciliation layering model to `GITOPS_MODEL.md`
- Extends `ENFORCEMENT_MATRIX.md` with the new Kyverno CI pre-validation gate

## Enforcement Matrix addition

New row documents: manifests must pass `kyverno apply` against the versioned policy snapshot in `gitops/platform/policies/kyverno/enforce/` before merge. Covers both BigBang-inherited and platform-authored ClusterPolicies. Hard fail on any Enforce-mode violation.

## Related

- Companion implementation: zavestudios/platform-pipelines#61 (reusable workflow)
- Companion implementation: zavestudios/gitops#182 (caller workflow + vendored policies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)