### PR TITLE
Define observability capability materialization in Formation

### DIFF
--- a/_platform/CONTRACT_SCHEMA.md
+++ b/_platform/CONTRACT_SCHEMA.md
@@ -283,6 +283,70 @@ Capability classes:
 v0.1 allows only feature capabilities.
 Structural capabilities are deferred until role/deployable-unit modeling is introduced in a future schema version.
 
+## Formation v0.1 Observability Capability Semantics
+
+`metrics` and `tracing` are valid feature capabilities in Formation, but their
+declaration is meaningful only when the platform materializes the corresponding
+GitOps and runtime behavior.
+
+Tenants declare observability intent in the contract.
+The platform defines collection mechanics, endpoints, labels, and controllers.
+
+### `metrics`
+
+Declaring:
+
+```yaml
+spec:
+  capabilities:
+    - name: metrics
+```
+
+means the workload is expected to expose Prometheus-format metrics on a
+platform-known endpoint.
+
+Formation expectations:
+
+- the workload exposes a named Kubernetes `Service` port `metrics`
+- the scrape path defaults to `/metrics`
+- GitOps materializes the scrape object required by the active monitoring stack
+- Prometheus discovers the workload through platform-owned selectors, not
+  ad hoc tenant scrape config
+
+Tenants do not author raw Prometheus scrape jobs in workload repositories.
+
+### `tracing`
+
+Declaring:
+
+```yaml
+spec:
+  capabilities:
+    - name: tracing
+```
+
+means the workload is expected to emit OpenTelemetry Protocol (OTLP) traces to
+a platform-owned collector path.
+
+Formation expectations:
+
+- workloads emit OTLP to a platform-owned in-cluster receiver
+- the receiver is platform-owned and forwards traces to the tracing backend
+- workloads must not send traces directly to Tempo or define tenant-specific
+  tracing backends
+- GitOps materializes the required environment variables, service endpoints,
+  and collector wiring
+
+The canonical Formation path is:
+
+```text
+workload -> platform-owned Alloy receiver -> Tempo
+```
+
+The exact receiver service address is a platform implementation detail and must
+be published through GitOps-managed configuration rather than hardcoded by
+tenants.
+
 ---
 
 # Resources Section (Optional)

--- a/_platform/GITOPS_MODEL.md
+++ b/_platform/GITOPS_MODEL.md
@@ -219,6 +219,93 @@ Once generators stabilize:
 
 ---
 
+## Formation Observability Capability Materialization
+
+During Formation, observability capability declarations are not self-executing.
+They become real only when GitOps includes the workload and platform resources
+needed for collection.
+
+### Metrics Capability
+
+For a workload declaring:
+
+```yaml
+spec:
+  capabilities:
+    - name: metrics
+```
+
+the Formation GitOps standard is:
+
+1. the tenant workload exposes a Kubernetes `Service` port named `metrics`
+2. the scrape path is `/metrics` unless the platform explicitly documents an
+   exception
+3. `gitops/tenants/{workload}/` contains the monitoring object required by the
+   active platform stack
+4. for the current Prometheus Operator implementation, that object is a
+   `ServiceMonitor`
+
+The `ServiceMonitor` must remain platform-shaped:
+
+- it targets the tenant namespace intentionally
+- it selects the workload `Service` by stable labels
+- it references the named `metrics` port rather than a raw port number
+
+Workload capability declaration without this GitOps materialization is
+conformance debt, not successful capability adoption.
+
+### Tracing Capability
+
+For a workload declaring:
+
+```yaml
+spec:
+  capabilities:
+    - name: tracing
+```
+
+the Formation GitOps standard is:
+
+1. the workload emits OTLP using platform-provided configuration
+2. GitOps publishes the platform-owned in-cluster OTLP receiver path
+3. the receiver is owned by the observability stack and forwards traces to
+   Tempo
+4. tenant manifests do not define direct Tempo ingestion, bespoke collectors,
+   or workload-specific tracing backends
+
+The canonical Formation data path is:
+
+```text
+workload -> Alloy receiver -> Tempo
+```
+
+Required materialization responsibilities:
+
+- platform GitOps defines the receiver service and routing path
+- tenant GitOps injects the receiver endpoint and required OTLP environment
+  variables into workloads that declare `tracing`
+- validation and generators should eventually enforce this automatically
+
+Until the receiver path is published and consumable through GitOps-managed
+configuration, `tracing` remains declared intent rather than completed platform
+behavior.
+
+### Operational Validation
+
+Capability materialization is not complete until the platform can verify it at
+runtime.
+
+Examples:
+
+- `metrics`: Prometheus shows the workload target as discovered and `up`
+- `tracing`: the collector receives workload traces and forwards them to Tempo
+
+This follows `DIAGNOSTIC_MODEL.md`: Git truth, rendered truth, controller
+truth, and runtime truth must align before a capability is considered
+operational.
+
+---
+
 ## Reconciliation Layering
 
 FluxCD reconciliation has three distinct ordering mechanisms. Using the wrong one is a common source of stalls.


### PR DESCRIPTION
## Summary

- define Formation-era semantics for the `metrics` and `tracing` capabilities
- document the GitOps materialization standard for `metrics`
- document the canonical tracing path as workload -> Alloy receiver -> Tempo

## Why

`zave.yaml` already allows workloads to declare `metrics` and `tracing`, but the platform docs did not define what those declarations are supposed to produce in GitOps or at runtime.

That gap became concrete while working `zavestudios/gitops#190`:

- `rigoberta` is now validated end to end for metrics via `ServiceMonitor`
- `mia` declares `tracing`, but the platform had no documented tenant-facing tracing materialization rule

This PR closes that doctrine gap without inventing a new document surface.

## Related

- Refs `zavestudios/platform-docs#77`
- Refs `zavestudios/gitops#190`
- Metrics validation work: `zavestudios/gitops#207` and `zavestudios/gitops#208`

## Notes

- The tracing section intentionally defines the canonical data path and ownership split without hardcoding a guessed receiver DNS name.
- The exact receiver service address remains a GitOps-managed platform implementation detail.
