### PR TITLE
Clarify stateful capability taxonomy

### DIFF
--- a/_platform/CONTRACT_SCHEMA.md
+++ b/_platform/CONTRACT_SCHEMA.md
@@ -251,6 +251,52 @@ This determines:
 
 Storage configuration must not appear outside this section.
 
+Formation guidance:
+
+- `spec.persistence` is reserved for backing stores that behave like
+  workload-attached data dependencies consumed through direct application
+  credentials.
+- `postgres` and `mysql` are the canonical relational examples for this
+  surface.
+- `redis` remains an allowed value in Formation v0.1 for compatibility with
+  current platform behavior.
+- This does not establish a general rule that caches, brokers, search systems,
+  or other shared stateful technologies belong under `spec.persistence`.
+
+Stateful technology categories such as message brokers, event streaming
+platforms, and search / analytics stores should be treated as separate platform
+capability families unless the platform explicitly decides they behave like
+workload-owned backing stores.
+
+---
+
+# Stateful Capability Taxonomy (Formation Guidance)
+
+Formation distinguishes between workload-owned persistence and shared
+stateful capabilities.
+
+Decision rule:
+
+- Use `spec.persistence` when the workload needs a primary backing store with
+  direct secret injection, connection policy, and backup / recovery semantics
+  that attach to that workload.
+- Do not add new `spec.persistence.engine` values for every stateful technology
+  category by default.
+- Treat shared systems such as brokers, streaming platforms, and search tiers
+  as separate capability families unless the contract is intentionally expanded
+  to support them.
+
+Examples of stateful capability families that should not be inferred from the
+current `persistence` enum:
+
+- message brokers
+- event streaming platforms
+- search / analytics stores
+- future shared cache tiers
+
+This keeps the persistence surface narrow while preserving a path for bounded
+future expansion.
+
 ---
 
 # Capability Section (Optional)
@@ -281,6 +327,8 @@ Capability classes:
   - queue-consumer
 
 v0.1 allows only feature capabilities.
+Stateful shared-service capability families are not yet part of the supported
+v0.1 workload contract surface.
 Structural capabilities are deferred until role/deployable-unit modeling is introduced in a future schema version.
 
 ---

--- a/_platform/CONTRACT_VALIDATION.md
+++ b/_platform/CONTRACT_VALIDATION.md
@@ -84,6 +84,8 @@ Checks:
 - Runtime supports chosen delivery strategy
 - Exposure type is permitted for the runtime
 - Persistence engine is supported in the environment
+- Stateful technology category is mapped to the correct contract surface
+  (`persistence` vs capability family)
 - Capability combinations are allowed
 - Resource tier fits platform constraints
 - Build strategy is supported for the contract version
@@ -98,6 +100,8 @@ Example failures:
 - Canary delivery on unsupported runtime
 - Public exposure in restricted environment
 - Redis persistence without network policy support
+- RabbitMQ declared as `spec.persistence.engine` without a schema version that
+  supports broker capability families
 - Conflicting capabilities attached
 
 ---

--- a/_platform/OPERATING_MODEL.md
+++ b/_platform/OPERATING_MODEL.md
@@ -333,6 +333,12 @@ Tenants propose new reusable capabilities via POC process:
 - Platform: Approve, implement as `redis` persistence engine
 - Result: All tenants can now use `persistence: engine: redis`
 
+Formation note:
+
+- This Redis example reflects current v0.1 contract compatibility, not a
+  general rule that every future stateful technology category should be added
+  under `spec.persistence.engine`.
+
 **Anti-Pattern**: Platform team guesses what capabilities tenants need without validation.
 
 ---


### PR DESCRIPTION
## Summary
- keep `spec.persistence` narrow as the workload-attached backing-store surface
- document Redis as a Formation-era compatibility case rather than precedent for broader enum expansion
- add validation guidance that stateful technologies must map to the correct contract surface

## Why
Issue #72 is trying to stop accidental contract drift while we evaluate broader stateful capability families such as brokers, streaming systems, and search stores. The current docs allowed `redis` to read like precedent for adding every stateful technology under `spec.persistence.engine`.

This change clarifies the Formation taxonomy without changing the canonical top-level contract shape or forcing tenant/runtime migration.

## Scope
- `CONTRACT_SCHEMA.md`
- `CONTRACT_VALIDATION.md`
- `OPERATING_MODEL.md`

## Testing
- documentation change only

## Related
- closes #72