### PR TITLE
[codex] Add observability operating model

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Read this repository like a small canonical handbook, not a wiki.
   Canonical execution environments, available tools, and where platform operations should run.
 - **GITOPS_MISSING_RESOURCE_RUNBOOK.md**
   Generic runbook for diagnosing GitOps-managed services or workloads that appear absent from the cluster.
+- **GITOPS_STALE_RECONCILIATION_RUNBOOK.md**
+  Generic runbook for diagnosing corrected GitOps inputs that do not converge into a fresh controller action.
 - **PR_WORKFLOW.md**
   Standard pull request workflow and conventions.
 - **RUNBOOK_METHODOLOGY.md**

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Read this repository like a small canonical handbook, not a wiki.
   Generator semantics and template-driven behavior.
 - **GITOPS_MODEL.md**
   How authoritative desired state is represented and advanced through GitOps.
+- **OBSERVABILITY_MODEL.md**
+  Classification, ownership, and capability materialization rules for logs, metrics, and traces.
 
 ### Execution And Operations
 

--- a/_platform/GITOPS_STALE_RECONCILIATION_RUNBOOK.md
+++ b/_platform/GITOPS_STALE_RECONCILIATION_RUNBOOK.md
@@ -1,0 +1,290 @@
+# GitOps Stale Reconciliation Runbook
+
+## Purpose
+
+This runbook covers the failure class where Git state and controller state have
+partially advanced, but the expected child controller action does not converge
+predictably.
+
+Use this when the first symptom is:
+
+- the corrective commit is merged
+- the owning `Kustomization` is still in progress or not ready
+- the child `HelmRelease` or controller still reports an earlier failure
+- the platform does not self-heal within the expected reconcile window
+
+---
+
+## Symptom
+
+An operator makes a corrective Git change, but the blocked reconciliation unit
+does not respond predictably.
+
+Typical examples:
+
+- upstream `Kustomization`s reconcile the new source revision, but the blocked
+  unit still appears stuck
+- `HelmRelease` status still shows the earlier failure after corrected inputs
+  are known to be live
+- the child controller does not create a fresh successful action without manual
+  intervention
+
+---
+
+## Required Inputs
+
+Before starting, identify:
+
+- `<gitops-repo>`: owning GitOps repository
+- `<owning-kustomization>`: top-level Flux `Kustomization` blocked on the
+  change
+- `<helmrelease-namespace>` and `<helmrelease-name>` if Helm is involved
+- `<expected-git-revision>`: commit SHA or source revision containing the fix
+- `<values-source-object>` if the release uses generated ConfigMaps or Secrets
+
+If ownership is unclear, stop and resolve it first using `REPO_TAXONOMY.md`,
+`OPERATING_MODEL.md`, and `GITOPS_MODEL.md`.
+
+---
+
+## Stale Threshold
+
+Treat the reconciliation as **stale**, not "still working", when all of the
+following are true:
+
+1. corrected Git state is merged
+2. the owning source and `Kustomization` have observed that state
+3. corrected generated inputs are live in the cluster
+4. one full reconcile interval for the blocked child controller has elapsed
+5. the child controller still reports the earlier failure or has not produced a
+   fresh attempt
+
+For `HelmRelease` objects, use the release's configured `spec.interval` as the
+default threshold unless there is stronger controller-specific evidence.
+
+---
+
+## Boundary Ladder
+
+### 1. Declared Truth
+
+Question:
+
+- does Git contain the corrective change you expect?
+
+Checks:
+
+```bash
+git -C /path/to/<gitops-repo> log --oneline -n 20
+git -C /path/to/<gitops-repo> show <expected-git-revision> -- <relevant-path>
+```
+
+Interpretation:
+
+- if the fix is not in Git, stop
+- if the fix is in Git, continue
+
+---
+
+### 2. Rendered Truth
+
+Question:
+
+- does the live rendered input actually reflect the fix?
+
+Checks:
+
+```bash
+kubectl get helmrelease -n <helmrelease-namespace> <helmrelease-name> -o yaml
+kubectl get configmap -n <helmrelease-namespace> <values-source-object> -o yaml
+kubectl get secret -n <helmrelease-namespace> <values-source-object> -o yaml
+```
+
+If a `valuesFrom` source is used, extract the actual payload:
+
+```bash
+kubectl get configmap -n <helmrelease-namespace> <values-source-object> \
+  -o jsonpath='{.data.values\.yaml}'
+```
+
+Interpretation:
+
+- if the live values source still contains the old bad input, the fix has not
+  reached rendered truth
+- if the live values source is corrected, continue
+
+---
+
+### 3. Controller Truth
+
+Question:
+
+- did the owning controller observe the corrected object, and did the child
+  controller create a fresh attempt?
+
+Checks:
+
+```bash
+kubectl describe kustomization -n flux-system <owning-kustomization>
+kubectl describe helmrelease -n <helmrelease-namespace> <helmrelease-name>
+```
+
+Focus on:
+
+- `metadata.generation`
+- `status.observedGeneration`
+- `status.lastAttemptedGeneration`
+- latest failure message
+- attempted release action
+- attempted revision
+
+Interpretation:
+
+- if `metadata.generation` is ahead of `status.observedGeneration`, the child
+  controller has not consumed the latest object yet
+- if the child controller has consumed the latest object but still reports the
+  earlier failure after corrected inputs are live, treat it as stale
+
+---
+
+### 4. Live Runtime Truth
+
+Question:
+
+- did the controller actually create a fresh action?
+
+Checks:
+
+```bash
+helm history <helmrelease-name> -n <helmrelease-namespace>
+kubectl get events -n <helmrelease-namespace> --sort-by=.lastTimestamp
+```
+
+Interpretation:
+
+- if no new action is recorded after the corrected input is live, the
+  reconciliation is stalled
+- if a new action is recorded and still fails, the fix is incomplete rather
+  than stale
+
+---
+
+## Decision Points
+
+### Corrected Input Is Not Live
+
+Outcome:
+
+- upstream apply/render path is still wrong
+
+Immediate action:
+
+```bash
+flux reconcile source git flux-system -n flux-system
+flux reconcile kustomization <owning-kustomization> -n flux-system --with-source
+```
+
+Owner:
+
+- owning GitOps path and Kustomization apply surface
+
+### Corrected Input Is Live But Child Controller Has Not Consumed Latest Generation
+
+Outcome:
+
+- child controller lag or blocked handoff
+
+Immediate action:
+
+```bash
+flux reconcile kustomization <owning-kustomization> -n flux-system --with-source
+```
+
+Owner:
+
+- controller handoff between Kustomization and child controller
+
+### Corrected Input Is Live, Generation Is Current, But No Fresh Successful Attempt Appears
+
+Outcome:
+
+- stale reconciliation
+
+Immediate action for Helm:
+
+```bash
+flux reconcile helmrelease <helmrelease-name> -n <helmrelease-namespace> --force
+```
+
+Interpretation:
+
+- if the forced reconcile succeeds, capture this as a stale-reconciliation
+  recovery
+- if the forced reconcile creates a new failure, follow the new failure instead
+
+Owner:
+
+- child controller behavior and platform control-plane design
+
+---
+
+## Recovery Actions
+
+Prefer declarative recovery first.
+
+### Declarative
+
+- merge the corrective Git change
+- reconcile source and owning `Kustomization`
+- verify corrected generated inputs are live
+
+### Break-Glass
+
+Use only once corrected inputs are already proven live and the child
+controller remains stale beyond the threshold.
+
+Example:
+
+```bash
+flux reconcile helmrelease <helmrelease-name> -n <helmrelease-namespace> --force
+```
+
+Any forced reconcile used to recover a stale control-plane state must be
+captured in the issue, incident note, or runbook update that follows.
+
+---
+
+## Escalation And Ownership
+
+Durable fix ownership depends on the failed boundary:
+
+- corrected input never reached the cluster: owning GitOps path
+- corrected input is live but child controller did not re-attempt: controller
+  behavior and control-plane design
+- forced reconcile succeeds: treat as a stale-reconciliation pattern and reduce
+  recurrence structurally
+
+If this failure class repeats:
+
+- update `gitops` with the environment-specific evidence and commands
+- update `platform-docs` if the pattern is generic across workloads or control
+  planes
+- audit `wait: true`, dependency chains, and top-level reconciliation blast
+  radius
+
+---
+
+## Minimal Command Bundle
+
+```bash
+kubectl describe kustomization -n flux-system <owning-kustomization>
+kubectl describe helmrelease -n <helmrelease-namespace> <helmrelease-name>
+kubectl get configmap -n <helmrelease-namespace> <values-source-object> -o yaml
+helm history <helmrelease-name> -n <helmrelease-namespace>
+flux reconcile source git flux-system -n flux-system
+flux reconcile kustomization <owning-kustomization> -n flux-system --with-source
+flux reconcile helmrelease <helmrelease-name> -n <helmrelease-namespace> --force
+```
+
+Use this bundle to determine whether the fix is missing, unconsumed, or stale
+before broadening scope.

--- a/_platform/OBSERVABILITY_MODEL.md
+++ b/_platform/OBSERVABILITY_MODEL.md
@@ -1,0 +1,204 @@
+# ZaveStudios — Observability Model v0.1
+
+## Chapter Guide
+
+**Purpose**
+
+Define how observability is classified, owned, and materialized across the
+platform during Formation.
+
+**Read this when**
+
+- deciding whether observability behavior belongs in a workload, GitOps, or
+  shared platform runtime
+- reviewing `metrics` and `tracing` capability declarations
+- defining rollout order for logs, metrics, and traces across governed
+  workloads
+
+**Read next**
+
+- `CONTRACT_SCHEMA.md` for capability semantics
+- `GITOPS_MODEL.md` for Formation materialization expectations
+- `CONTROL_PLANE_MODEL.md` for authority boundaries
+
+---
+
+## Classification
+
+Observability is a **hybrid platform concern**:
+
+- a **shared platform service surface** for collection, storage, query, and
+  operator access
+- a **workload capability surface** for tenant-declared intent such as
+  `tracing` and `metrics`
+
+It is not purely a tenant-local integration and it is not purely a hidden
+platform internal.
+
+Why:
+
+- collection paths are shared across workloads
+- storage and query backends are platform-owned
+- access and auth to operator surfaces are platform concerns
+- tenant signal emission must still be declared intentionally
+
+Therefore:
+
+- tenants declare observability intent
+- platform GitOps materializes the collection and routing path
+- operator access and baseline workflow remain platform-owned
+
+---
+
+## Formation Scope
+
+In Formation v0.1, the current observability stack is composed of shared
+runtime components and workload-specific materialization.
+
+Shared runtime examples include:
+
+- Grafana for dashboards and exploration
+- Loki for logs
+- Prometheus for metrics
+- Tempo for traces
+- Alloy for collection and forwarding
+
+Tenant workloads do not define their own observability backends as the normal
+governed path.
+
+---
+
+## Ownership Model
+
+### Platform Docs
+
+`platform-docs` owns:
+
+- capability semantics
+- ownership boundaries
+- canonical operator workflow
+- rules for what counts as completed observability materialization
+
+### GitOps
+
+`gitops` owns:
+
+- runtime installation and reconciliation of the shared observability stack
+- platform-owned collector and routing resources
+- tenant manifest materialization required to connect workloads to that stack
+
+### Tenant Repositories
+
+Tenant repositories own:
+
+- declaring supported observability intent in `zave.yaml`
+- application-level instrumentation or plugin enablement
+- any workload-local config required to emit signals through the platform path
+
+Tenants do not own:
+
+- direct backend selection
+- bespoke collector topologies as the default governed path
+- ad hoc operator access patterns
+
+---
+
+## Canonical Paths
+
+### Logs
+
+The canonical Formation path for logs is:
+
+```text
+workload stdout/stderr or structured app logs -> platform collector path -> Loki -> Grafana
+```
+
+### Metrics
+
+The canonical Formation `metrics` capability remains a Prometheus-style scrape
+path:
+
+```text
+workload metrics endpoint -> Service -> ServiceMonitor -> Prometheus -> Grafana
+```
+
+Implications:
+
+- declaring `metrics` means the workload exposes a scrapeable metrics endpoint
+- GitOps must materialize the monitoring object required by the active stack
+- OTLP metrics emitted by a workload may be useful implementation detail, but
+  do not by themselves satisfy the current Formation `metrics` capability
+  contract unless the contract and GitOps standard are explicitly expanded
+
+### Traces
+
+The canonical Formation `tracing` path is:
+
+```text
+workload -> platform-owned Alloy receiver -> Tempo -> Grafana
+```
+
+Implications:
+
+- workloads emit OTLP using platform-published configuration
+- workloads do not send traces directly to Tempo
+- the receiver and forwarding path are platform-owned runtime concerns
+
+---
+
+## Capability Completion Rules
+
+An observability capability is not complete when it is only declared in the
+contract.
+
+It is complete only when all of the following are true:
+
+1. contract intent is declared
+2. GitOps materialization exists
+3. the responsible controller reconciles successfully
+4. the live runtime path is verifiable
+5. an operator can follow the documented workflow to see the signal
+
+This follows `DIAGNOSTIC_MODEL.md`: declared truth, rendered truth, controller
+truth, runtime truth, and user-visible behavior must line up.
+
+---
+
+## Workload Selection Rule
+
+Do not force the same first validation workload to prove every signal type.
+
+Use the workload that best matches the capability being validated:
+
+- `mia` is the current tracing validation workload
+- `rigoberta` is the current metrics materialization example because it already
+  uses the Prometheus-style `ServiceMonitor` path
+
+If a workload does not yet satisfy the canonical semantics of a capability, its
+contract should not claim that capability as complete platform behavior.
+
+---
+
+## Rollout Guidance
+
+Recommended Formation sequence:
+
+1. stabilize the shared platform observability runtime
+2. prove one tracing workload end to end
+3. prove one metrics workload end to end
+4. document the operator workflow: request -> logs -> metrics -> trace
+5. expand capability rollout to additional governed workloads
+6. automate validation and generation where feasible
+
+This keeps doctrine aligned with live platform behavior instead of letting
+capability declarations outrun materialization.
+
+---
+
+## See Also
+
+- `CONTRACT_SCHEMA.md`
+- `GITOPS_MODEL.md`
+- `CONTROL_PLANE_MODEL.md`
+- `DIAGNOSTIC_MODEL.md`
+- `OPERATING_MODEL.md`


### PR DESCRIPTION
## Summary
- add `OBSERVABILITY_MODEL.md` as an authoritative platform model
- classify observability as a hybrid platform concern
- define ownership boundaries across `platform-docs`, `gitops`, and tenant repos
- codify current Formation semantics for logs, metrics, and traces
- index the new model in the handbook README

## Why
The observability thread had crossed from runtime bring-up into operating-model territory. The platform needed an explicit doctrine surface that explains:
- what observability is in platform terms
- which repo owns which part of the behavior
- what counts as completed capability materialization
- why `mia` should be treated as tracing validation while metrics remain a separate track

## Impact
- gives `platform-docs#79` a durable authoritative artifact
- keeps contract declarations aligned with actual GitOps/runtime materialization
- creates a stable reference for later validation and generator work

## Validation
- checked consistency against `CONTRACT_SCHEMA.md`, `GITOPS_MODEL.md`, `CONTROL_PLANE_MODEL.md`, and `DIAGNOSTIC_MODEL.md`
- limited this PR to the new observability model and README index entry
