### PR TITLE
Add observability data flow artifact

### DIFF
--- a/_platform/DIAGNOSTIC_MODEL.md
+++ b/_platform/DIAGNOSTIC_MODEL.md
@@ -209,6 +209,8 @@ To improve legibility, prefer the following artifacts:
 - environment-specific command bundles where needed
 - incident summaries that capture manual repair steps
 - inventories for critical shared services
+- diagrams or infographics when a flow, dependency graph, or ownership boundary
+  is easier to understand visually than through prose
 
 Avoid relying on:
 

--- a/_platform/observability/OBSERVABILITY_DATA_FLOW.md
+++ b/_platform/observability/OBSERVABILITY_DATA_FLOW.md
@@ -76,6 +76,22 @@ notification channels such as email, Slack, webhooks, or paging systems.
 
 ## Operator Examples
 
+### Request Investigation Workflow
+
+The canonical operator path starts from a user-visible request or symptom and
+uses Grafana as the primary interface:
+
+1. Find workload logs in Loki for the affected namespace, workload, and time
+   window.
+2. Check Prometheus metrics and target health for the workload and the
+   relevant collector/backend components.
+3. Inspect a Tempo trace for the same request class when tracing is enabled.
+4. Check Grafana or Alertmanager alert visibility for related firing alerts or
+   notification state.
+
+Direct cluster shell access is a fallback diagnostic path, not the standard
+operator workflow.
+
 ### Mia Trace Example
 
 1. Mia receives a WhatsApp message.


### PR DESCRIPTION
## Summary

- Add an observability data-flow note covering traces, metrics, logs, alerts, and terminology.
- Add a diagram artifact for push, scrape, store, query, and alert paths.
- Document the canonical operator workflow from request investigation through logs, metrics, traces, and alert visibility.
- Link the data-flow note from the observability model.

## Related

- Closes zavestudios/platform-docs#79
- References zavestudios/gitops#190
- References zavestudios/gitops#343

## Testing

- Ran `git diff --check`