### PR TITLE
docs: add PLATFORM_THESIS

### DIFF
--- a/_platform/PLATFORM_THESIS.md
+++ b/_platform/PLATFORM_THESIS.md
@@ -1,0 +1,84 @@
+# ZaveStudios — Platform Thesis
+
+## Purpose
+
+ZaveStudios is an Internal Developer Platform purpose-built for secure data pipeline hosting.
+
+Its reason for existing is to make it fast, safe, and repeatable to build and operate workloads that move, transform, and protect data — without rebuilding the security and infrastructure plumbing each time.
+
+---
+
+## The Core Insight
+
+Practically all of IT exists in service of data: storage, compute, networking, security, and observability are all mechanisms for moving, transforming, and protecting it.
+
+An IDP that makes it easier to build and operate the workloads that do that work has a clear, defensible reason to exist.
+
+---
+
+## Platform Identity
+
+ZaveStudios is a product, not a project.
+
+A product requires a clear customer problem. Ours is: organizations need to run data pipelines in a governed, secure, repeatable way without every team rebuilding the same infrastructure decisions from scratch.
+
+The platform solves that problem by owning the security posture, lifecycle mechanics, and infrastructure composition — so tenants focus on data logic, not plumbing.
+
+---
+
+## Tenant Profile
+
+The tenant is a team building workloads that participate in a data pipeline:
+
+- **Ingest** — extract and validate data from external sources
+- **Transform** — apply business rules, quality checks, and enrichment
+- **Load** — persist processed data to target systems
+- **Orchestrate** — schedule and coordinate pipeline execution (Airflow)
+- **Train** — build and iterate on ML models against pipeline-produced data
+- **Serve** — expose inference endpoints or pipeline outputs to consumers
+
+Tenants declare what kind of workload they are.
+The platform handles how it runs.
+
+---
+
+## What the Platform Owns
+
+The platform is responsible for security posture by construction:
+
+- Identity and access (SSO, RBAC, secret management)
+- Network policy and ingress
+- Policy enforcement (admission control, compliance guardrails)
+- Observability wiring (metrics, traces, logs)
+- Lifecycle authority (GitOps-managed delivery)
+- Data access controls and secret injection
+
+Tenants should not need to understand how these work. They should simply receive them.
+
+---
+
+## Why Security Hosting
+
+Data pipelines in regulated and security-conscious environments carry explicit requirements: data provenance, access control, audit trails, and compliance posture. These requirements are constant across workloads.
+
+A platform that satisfies them by construction — rather than relying on each tenant team to interpret and implement them independently — is the leverage point. The constrained path must be the compliant path.
+
+---
+
+## Relationship to Architectural Doctrine
+
+This thesis is the "why."
+
+`ARCHITECTURAL_DOCTRINE_TIER0.md` is the "what we will not compromise."
+
+`OPERATING_MODEL.md` is the "how we operate today."
+
+When those documents appear to conflict, the thesis is the tiebreaker.
+
+---
+
+## See Also
+
+- `ARCHITECTURAL_DOCTRINE_TIER0.md`
+- `OPERATING_MODEL.md`
+- `REPO_TAXONOMY.md`


### PR DESCRIPTION
## Summary

Adds `PLATFORM_THESIS.md` — the foundational purpose statement for ZaveStudios.

- Defines the platform as an IDP purpose-built for secure data pipeline hosting
- Establishes the tenant profile: ingest, transform, load, orchestrate, train, serve
- Articulates why the platform owns security posture by construction
- Positions the thesis above ARCHITECTURAL_DOCTRINE_TIER0 as the tiebreaker document

## Why now

The platform has reached a point where the Formation phase gap analysis shows strong structural progress. Before accelerating capability work, the purpose needed to be explicit and durable so future decisions have a clear filter.